### PR TITLE
Make constituency shapefile importer faster & more memory efficient

### DIFF
--- a/app/Console/Commands/ImportConstituencyGeojsonCommand.php
+++ b/app/Console/Commands/ImportConstituencyGeojsonCommand.php
@@ -3,39 +3,53 @@
 namespace App\Console\Commands;
 
 use App\Models\Constituency;
-use Illuminate\Console\Command;
+use \JsonMachine\Items;
 
-class ImportConstituencyGeojsonCommand extends Command
+class ImportConstituencyGeojsonCommand extends BaseImportCommand
 {
     protected $signature = 'import:constituency-geojson';
-
     protected $description = 'Import GeoJSON data for constituencies.';
+    protected $filename = 'fixtures/pcon24.geojson';
+
+    public function importRow($row)
+    {
+        $constituency = Constituency::where('gss_code', $row['properties']['PCON24CD'])->first();
+
+        if (! $constituency) {
+            $this->warn("Constituency not found: {$row['properties']['PCON24NM']} ({$row['properties']['PCON24CD']})");
+            return null;
+        }
+
+        $constituency->update([
+            'geojson' => $row,
+        ]);
+
+        return $constituency;
+    }
 
     public function handle()
     {
-        $file = database_path('fixtures/pcon24.geojson');
+        $this->outputTitle();
 
-        if (!file_exists($file)) {
-            $this->error('GeoJSON file not found.');
-            return;
+        $file = $this->getFile();
+        if (! $file) {
+            return 1;
         }
 
-        $json = json_decode(file_get_contents($file), true);
+        $features = Items::fromFile($file, ['pointer' => '/features']);
 
-        foreach ($json['features'] as $geojson) {
-            $constituency = Constituency::where('gss_code', $geojson['properties']['PCON24CD'])->first();
+        $this->output->progressStart(iterator_count(Items::fromFile($file, ['pointer' => '/features'])));
 
-            if (! $constituency) {
-                $this->warn('Constituency not found: ' . $geojson['properties']['PCON24CD']);
-                continue;
-            }
-
-            $this->info('Updating constituency: ' . $constituency->name);
-
-            // Convert all coordinates to WGS84.
-            $constituency->update([
-                'geojson' => $geojson,
-            ]);
+        foreach ($features as $featureObj) {
+            $this->output->progressAdvance();
+            $feature = json_decode(json_encode($featureObj), true);
+            $this->importRow($feature);
         }
+
+        $this->output->progressFinish();
+
+        $this->outputPostscript();
+
+        return 0;
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -6,6 +6,7 @@
     "license": "MIT",
     "require": {
         "php": "^8.2",
+        "halaxa/json-machine": "^1.2",
         "laravel/framework": "^11.9",
         "laravel/tinker": "^2.9",
         "livewire/livewire": "^3.5",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7de70ce13be9eef367997e68e9cfe5d0",
+    "content-hash": "6771c5539e138d3ff63e212d65d0edf5",
     "packages": [
         {
             "name": "brick/math",
@@ -1191,6 +1191,68 @@
                 }
             ],
             "time": "2023-12-03T19:50:20+00:00"
+        },
+        {
+            "name": "halaxa/json-machine",
+            "version": "1.2.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/halaxa/json-machine.git",
+                "reference": "58fb6e97c53c3341bb1f3685b8bdbeedf3f9616c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/halaxa/json-machine/zipball/58fb6e97c53c3341bb1f3685b8bdbeedf3f9616c",
+                "reference": "58fb6e97c53c3341bb1f3685b8bdbeedf3f9616c",
+                "shasum": ""
+            },
+            "require": {
+                "php": "7.2 - 8.4"
+            },
+            "require-dev": {
+                "ext-json": "*",
+                "friendsofphp/php-cs-fixer": "^3.0",
+                "phpstan/phpstan": "^1.10",
+                "phpunit/phpunit": "^8.0"
+            },
+            "suggest": {
+                "ext-json": "To run JSON Machine out of the box without custom decoders.",
+                "guzzlehttp/guzzle": "To run example with GuzzleHttp"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/functions.php"
+                ],
+                "psr-4": {
+                    "JsonMachine\\": "src/"
+                },
+                "exclude-from-classmap": [
+                    "src/autoloader.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "Filip Halaxa",
+                    "email": "filip@halaxa.cz"
+                }
+            ],
+            "description": "Efficient, easy-to-use and fast JSON pull parser",
+            "support": {
+                "issues": "https://github.com/halaxa/json-machine/issues",
+                "source": "https://github.com/halaxa/json-machine/tree/1.2.3"
+            },
+            "funding": [
+                {
+                    "url": "https://ko-fi.com/G2G57KTE4",
+                    "type": "other"
+                }
+            ],
+            "time": "2025-05-30T12:36:04+00:00"
         },
         {
             "name": "laravel/framework",
@@ -8987,12 +9049,12 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {},
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
         "php": "^8.2"
     },
-    "platform-dev": [],
+    "platform-dev": {},
     "plugin-api-version": "2.6.0"
 }


### PR DESCRIPTION
This streams the large GeoJSON file, instead of loading it all into memory. It also switches to use the BaseImportCommand introduced in #38, for consistency.